### PR TITLE
Elaborate setup instructions and creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Crop here create a copy of the `.env` that configures environmental variables fo
 
     cp .env_example .env
 
-Edit it and update your MONGODB, COOKIE_SECRET, and URL settings.
-
-The last thing you need to do is update the admin user that will be created the first time you start your app. For now, this is set in `/updates/0.0.1-admins.js`. Ideally, we will prompt for admin user settings on first run. [(See issue #94)](https://github.com/ExchangeJS/exchangejs-org/issues/94).
+Edit it and update your MONGO_URI, COOKIE_SECRET, and URL settings.
 
 You can then run the local development server with:
 
     yarn dev
+
+Once the app is running, go to your localhost:3000/keystone (or, if you changed the URL or port in the config file, whatever is appropriate) and login with 'user@example.com' and 'admin' as the password. Once logged in, select Users and change your information.
 
 To deploy your changes just push to GitHub. Once they're merged into master
 they'll deploy to Heroku and our site automatically in a few minutes.

--- a/updates/0.0.1-admins.js
+++ b/updates/0.0.1-admins.js
@@ -2,14 +2,14 @@
  * This script automatically creates a default Admin user when an
  * empty database is used for the first time. You can use this
  * technique to insert data into any List you have defined.
- * 
+ *
  * Alternatively, you can export a custom function for the update:
  * module.exports = function(done) { ... }
  */
 
 exports.create = {
 	User: [
-		{ 'name.first': 'Admin', 'name.last': 'User', email: 'ydenberg@gmail.com', password: 'admin', isAdmin: true }
+		{ 'name.first': 'Admin', 'name.last': 'User', email: 'user@example.com', password: 'admin', isAdmin: true }
 	]
 };
 
@@ -26,9 +26,9 @@ var admins = [
 ];
 
 function createAdmin(admin, done) {
-	
+
 	var newAdmin = new User.model(admin);
-	
+
 	newAdmin.isAdmin = true;
 	newAdmin.save(function(err) {
 		if (err) {
@@ -39,7 +39,7 @@ function createAdmin(admin, done) {
 		}
 		done(err);
 	});
-	
+
 }
 
 exports = module.exports = function(done) {


### PR DESCRIPTION
Quick solution to #94, remove my email and then expand the README for changing username / password using the CMS once the app is running.

It's possible I suppose to do it using a prompt but it would have to integrate with keystone's setup scripts in some way so that it doesn't run every time you start the app. It's a 1-time thing so I don't think it's high-priority (and for running locally it doesn't really matter).