### PR TITLE
fix sponsorship links to used defined route

### DIFF
--- a/views/base.hbs
+++ b/views/base.hbs
@@ -77,7 +77,7 @@
             <li><a href="https://getjobber.com/" target="_blank">Jobber</a></li>
             <li><a href="https://www.startupedmonton.com/" target="_blank">Startup Edmonton</a></li>
             <li><a href="https://www.dotdash.com/" target="_blank">Dotdash</a></li>
-            <li><a href="./sponsorship.html">Become a sponsor!</a></li>
+            <li><a href="/sponsorship">Become a sponsor!</a></li>
           </ul>
           <h3 id="organizers">Organizers</h3>
           <ul class="list-unstyled">

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -24,7 +24,7 @@
         those wishing to stay out later. All participants agree to follow our <a href="/code-of-conduct/">code of conduct</a>.
       </p>
       <p>
-        Support Edmonton's JavaScript community and <a href="./sponsorship.html">become a sponsor today</a>.
+        Support Edmonton's JavaScript community and <a href="/sponsorship">become a sponsor today</a>.
       </p>
     </section>
 


### PR DESCRIPTION
The sponsorship links in the footer, and in the main index page body, pointed to an incorrect URL. They have been fixed to use the route defined, and correctly point to the Google Form.